### PR TITLE
Code review changes

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -1,7 +1,8 @@
 #include "iddtypes.hpp"
 #include <CLI/CLI.hpp>
 #include <third_party/nlohmann/json.hpp>
-#include <stdio.h>
+#include <cstdio>
+#include <algorithm>
 #include <iostream>
 #include <fstream>
 #include <boost/filesystem.hpp>
@@ -33,7 +34,6 @@ json & removeUnusedObjects(json & jsonidf) {
       ++typep;
     }
   }
-
   return jsonidf;
 }
 
@@ -229,14 +229,14 @@ int createFMU(const std::string &jsoninput, bool nozip, bool nocompress) {
     const auto var = varpair.second;
 
     auto scalarVar = xmlvariables.append_child("ScalarVariable");
-		for (const auto & attribute : var.scalar_attributes) {
-    	scalarVar.append_attribute(attribute.first.c_str()) = attribute.second.c_str();
-		}
+    for (const auto & attribute : var.scalar_attributes) {
+      scalarVar.append_attribute(attribute.first.c_str()) = attribute.second.c_str();
+    }
 
     auto real = scalarVar.append_child("Real");
-		for (const auto & attribute : var.real_attributes) {
-    	real.append_attribute(attribute.first.c_str()) = attribute.second.c_str();
-		}
+    for (const auto & attribute : var.real_attributes) {
+      real.append_attribute(attribute.first.c_str()) = attribute.second.c_str();
+    }
   }
 
   doc.save_file(modelDescriptionPath.c_str());

--- a/epfmi/EPComponent.cpp
+++ b/epfmi/EPComponent.cpp
@@ -18,18 +18,20 @@ EPComponent::EPComponent(const std::string & name, const boost::filesystem::path
 {
   boost::system::error_code ec;
   for ( const auto & entry : boost::filesystem::directory_iterator(resourcePath, ec) ) {
-    const auto path = entry.path();
-    const auto extension = path.extension();
-    if ( extension == ".idf" ) {
-      idfInputPath = path.string();
-    } else if ( extension == ".epw" ) {
-      weatherFilePath = path.string();
-    } else if ( extension == ".idd" ) {
-      iddPath = path.string();
-    } else if ( extension == ".spawn" ) {
-      spawnInputPath = path.string();
-    } else if ( extension == ".json" ) {
-      spawnInputPath = path.string();
+    if (ec.value() == boost::system::errc::success) {
+      const auto path = entry.path();
+      const auto extension = path.extension();
+      if ( extension == ".idf" ) {
+        idfInputPath = path.string();
+      } else if ( extension == ".epw" ) {
+        weatherFilePath = path.string();
+      } else if ( extension == ".idd" ) {
+        iddPath = path.string();
+      } else if ( extension == ".spawn" ) {
+        spawnInputPath = path.string();
+      } else if ( extension == ".json" ) {
+        spawnInputPath = path.string();
+      }
     }
   }
 
@@ -40,7 +42,7 @@ int EPComponent::start() {
   const auto & simulation = [&](){
     auto workingPath = boost::filesystem::path(instanceName).filename();
 
-    const int argc = 8;
+    constexpr int argc = 8;
     const char * argv[argc];
     argv[0] = "energyplus";
     argv[1] = "-d";
@@ -53,14 +55,14 @@ int EPComponent::start() {
 
     EnergyPlus::CommandLineInterface::ProcessArgs( argc, argv );
     EnergyPlus::DataGlobals::externalHVACManager = std::bind(&EPComponent::externalHVACManager, this);
-		try {
-    	auto result = RunEnergyPlus();
-  		std::unique_lock<std::mutex> lk(control_mutex);
-			epstatus = result ? EPStatus::ERROR : EPStatus::DONE;
-		} catch(...) {
-			epstatus = EPStatus::ERROR;
-		}
-  	control_cv.notify_one();
+    try {
+      auto result = RunEnergyPlus();
+      std::unique_lock<std::mutex> lk(control_mutex);
+      epstatus = result ? EPStatus::ERROR : EPStatus::DONE;
+    } catch(...) {
+      epstatus = EPStatus::ERROR;
+    }
+    control_cv.notify_one();
   };
 
   {
@@ -71,7 +73,7 @@ int EPComponent::start() {
 
   simthread = std::thread(simulation);
 
-	// Wait for EnergyPlus to go through startup/warmup etc
+  // Wait for EnergyPlus to go through startup/warmup etc
   return controlWait();
 }
 
@@ -81,14 +83,14 @@ int EPComponent::stop() {
     epstatus = EPStatus::TERMINATE;
   }
 
-	try {
-  	stopSimulation();
-  	control_cv.notify_one();
-  	simthread.join();
-  	return 0;
-	} catch(...) {
-  	return 1;
-	}
+  try {
+    stopSimulation();
+    control_cv.notify_one();
+    simthread.join();
+    return 0;
+  } catch(...) {
+    return 1;
+  }
 }
 
 int EPComponent::setTime(const double & time)
@@ -101,10 +103,11 @@ int EPComponent::setTime(const double & time)
     std::unique_lock<std::mutex> lk(control_mutex);
     epstatus = EPStatus::ADVANCE;
   }
+
   // Notify E+ to advance
   control_cv.notify_one();
 
-	// Wait for EnergyPlus to complete the step
+  // Wait for EnergyPlus to complete the step
   return controlWait();
 }
 
@@ -146,30 +149,21 @@ double EPComponent::getValue(const unsigned int & ref) const {
 
 Real64 EPComponent::zoneHeatTransfer(const int ZoneNum)
 {
-    static Real64 SumIntGain(0.0); // Zone sum of convective internal gains
-    static Real64 SumHA(0.0);      // Zone sum of Hc*Area
-    static Real64 SumHATsurf(0.0); // Zone sum of Hc*Area*Tsurf
-    static Real64 SumHATref(0.0);  // Zone sum of Hc*Area*Tref, for ceiling diffuser convection correlation
-    static Real64 SumMCp(0.0);     // Zone sum of MassFlowRate*Cp
-    static Real64 SumMCpT(0.0);    // Zone sum of MassFlowRate*Cp*T
-    static Real64 SumSysMCp(0.0);  // Zone sum of air system MassFlowRate*Cp
-    static Real64 SumSysMCpT(0.0); // Zone sum of air system MassFlowRate*Cp*T
+  EnergyPlus::ZoneTempPredictorCorrector::CalcZoneSums(ZoneNum, SumIntGain, SumHA, SumHATsurf, SumHATref, SumMCp, SumMCpT, SumSysMCp, SumSysMCpT);
 
-    EnergyPlus::ZoneTempPredictorCorrector::CalcZoneSums(ZoneNum, SumIntGain, SumHA, SumHATsurf, SumHATref, SumMCp, SumMCpT, SumSysMCp, SumSysMCpT);
+  const auto TempDepCoef = SumHA;                   // + SumMCp;
+  const auto TempIndCoef = SumIntGain + SumHATsurf; // - SumHATref + SumMCpT;
 
-    Real64 TempDepCoef = SumHA;                   // + SumMCp;
-    Real64 TempIndCoef = SumIntGain + SumHATsurf; // - SumHATref + SumMCpT;
+  // Refer to
+  // https://bigladdersoftware.com/epx/docs/8-8/engineering-reference/basis-for-the-zone-and-air-system-integration.html#basis-for-the-zone-and-air-system-integration
+  const auto heatTransfer = TempIndCoef - (TempDepCoef * EnergyPlus::DataHeatBalFanSys::MAT(ZoneNum));
 
-    // Refer to
-    // https://bigladdersoftware.com/epx/docs/8-8/engineering-reference/basis-for-the-zone-and-air-system-integration.html#basis-for-the-zone-and-air-system-integration
-    Real64 heatTransfer = TempIndCoef - (TempDepCoef * EnergyPlus::DataHeatBalFanSys::MAT(ZoneNum));
-
-    return heatTransfer;
+  return heatTransfer;
 }
 
 void EPComponent::exchange()
 {
-  auto zoneNum = [](std::string & zoneName) {
+  const auto zoneNum = [](std::string & zoneName) {
     std::transform(zoneName.begin(), zoneName.end(), zoneName.begin(), ::toupper);
     for ( int i = 0; i < EnergyPlus::DataGlobals::NumOfZones; ++i ) {
       if ( EnergyPlus::DataHeatBalance::Zone[i].Name == zoneName ) {
@@ -180,37 +174,37 @@ void EPComponent::exchange()
     return 0;
   };
 
-  auto getSensorValue = [&](Variable & var) {
+  const auto getSensorValue = [&](Variable & var) {
     const auto & h = getVariableHandle(var.outputvarname.c_str(), var.outputvarkey.c_str());
     return getVariableValue(h);
   };
 
-  auto compSetActuatorValue = [](const std::string & key, const std::string & componenttype, const std::string & controltype, const Real64 & value) {
+  const auto compSetActuatorValue = [](const std::string & key, const std::string & componenttype, const std::string & controltype, const Real64 & value) {
     const auto & h = getActuatorHandle(key.c_str(), componenttype.c_str(), controltype.c_str());
     setActuatorValue(h, value);
   };
 
-  auto compResetActuator = [](const std::string & key, const std::string & componenttype, const std::string & controltype) {
+  const auto compResetActuator = [](const std::string & key, const std::string & componenttype, const std::string & controltype) {
     const auto & h = getActuatorHandle(key.c_str(), componenttype.c_str(), controltype.c_str());
     resetActuator(h);
   };
 
-	auto actuateVar = [&](const Variable & var) {
-		if( var.valueset ) {
-		  compSetActuatorValue(
-		    var.actuatorcomponentkey,
-		    var.actuatorcomponenttype,
-		    var.actuatorcontroltype,
-		    var.value
-		  );
-		} else {
-		  compResetActuator(
-		    var.actuatorcomponentkey,
-		    var.actuatorcomponenttype,
-		    var.actuatorcontroltype
-		  );
-		}
-	};
+  const auto actuateVar = [&](const Variable & var) {
+    if( var.valueset ) {
+      compSetActuatorValue(
+          var.actuatorcomponentkey,
+          var.actuatorcomponenttype,
+          var.actuatorcontroltype,
+          var.value
+      );
+    } else {
+      compResetActuator(
+          var.actuatorcomponentkey,
+          var.actuatorcomponenttype,
+          var.actuatorcontroltype
+      );
+    }
+  };
 
   // Update inputs first, then outputs so that we can do some updates within EnergyPlus
   for( auto & varmap : variables ) {
@@ -225,10 +219,10 @@ void EPComponent::exchange()
         }
         break;
       case VariableType::EMS_ACTUATOR:
-				actuateVar(var);
+        actuateVar(var);
         break;
       case VariableType::SCHEDULE:
-				actuateVar(var);
+        actuateVar(var);
       default:
         break;
     }
@@ -270,15 +264,15 @@ void EPComponent::exchange()
 }
 
 int EPComponent::controlWait() {
-	std::unique_lock<std::mutex> lk(control_mutex);
-	// Wait until EnergyPlus is not Advancing or Terminating (ie in the process of cleanup)
-	control_cv.wait( lk, [&](){
-		return
-			(epstatus == EPStatus::NONE) ||
-			(epstatus == EPStatus::ERROR) ||
-			(epstatus == EPStatus::DONE);
-	});
-	return epstatus == EPStatus::ERROR ? 1 : 0;
+  std::unique_lock<std::mutex> lk(control_mutex);
+  // Wait until EnergyPlus is not Advancing or Terminating (ie in the process of cleanup)
+  control_cv.wait( lk, [&](){
+    return
+        (epstatus == EPStatus::NONE) ||
+        (epstatus == EPStatus::ERROR) ||
+        (epstatus == EPStatus::DONE);
+  });
+  return epstatus == EPStatus::ERROR ? 1 : 0;
 }
 
 void EPComponent::externalHVACManager() {
@@ -295,7 +289,7 @@ void EPComponent::externalHVACManager() {
   }
 
   if( EnergyPlus::DataGlobals::KickOffSimulation ) {
-      return;
+    return;
   }
 
   // Only signal and wait for input if the current sim time is greather than or equal
@@ -309,12 +303,13 @@ void EPComponent::externalHVACManager() {
 
   // Signal the end of the step
   {
+    std::unique_lock<std::mutex> lk(control_mutex);
     if (epstatus != EPStatus::TERMINATE)
     {
-      std::unique_lock<std::mutex> lk(control_mutex);
-      epstatus = EPStatus::NONE;
+     epstatus = EPStatus::NONE;
     }
   }
+
   control_cv.notify_one();
 
   // Wait for the epstatus to advance again

--- a/epfmi/EPComponent.hpp
+++ b/epfmi/EPComponent.hpp
@@ -110,11 +110,19 @@ public:
   std::map<unsigned int, Variable> variables;
 
 private:
+  Real64 SumIntGain{0.0}; // Zone sum of convective internal gains
+  Real64 SumHA{0.0};      // Zone sum of Hc*Area
+  Real64 SumHATsurf{0.0}; // Zone sum of Hc*Area*Tsurf
+  Real64 SumHATref{0.0};  // Zone sum of Hc*Area*Tref, for ceiling diffuser convection correlation
+  Real64 SumMCp{0.0};     // Zone sum of MassFlowRate*Cp
+  Real64 SumMCpT{0.0};    // Zone sum of MassFlowRate*Cp*T
+  Real64 SumSysMCp{0.0};  // Zone sum of air system MassFlowRate*Cp
+  Real64 SumSysMCpT{0.0}; // Zone sum of air system MassFlowRate*Cp*T
 
-	// Wait for the EnergyPlus thread from the control thread
-	// Return 0 on success
-	// This should be called from the control thread
-	int controlWait();
+  // Wait for the EnergyPlus thread from the control thread
+  // Return 0 on success
+  // This should be called from the control thread
+  int controlWait();
   Real64 zoneHeatTransfer(const int ZoneNum);
 
   fmi2Real requestedTime;

--- a/epfmi/Variables.hpp
+++ b/epfmi/Variables.hpp
@@ -28,11 +28,11 @@ enum class VariableType {
 using VariableAttribute = std::pair<std::string, std::string>;
 
 struct Variable {
-  VariableType type;
+  VariableType type{};
   std::string name;
 
-  Real64 value;
-  bool valueset; // This is true "value" member has been set to a value
+  Real64 value{};
+  bool valueset{false}; // This is true "value" member has been set to a value
 
   std::vector<VariableAttribute> scalar_attributes;
   std::vector<VariableAttribute> real_attributes;


### PR DESCRIPTION
 - Possible race condition with check and set of epstate
 - Proper use of emplace_back
 - A few formatting fixes
 - Reduction of global state when exchanging data
 - Reduction of `std::move`
    - Note, this still needs more cleanup, there is a lot of
      code duplication where Variable objects are created
 - More use of `auto` where appropriate
 - Lean towards `const` as the default for variable declarations
 - Logical fixes for error checking