### PR TITLE
Make exedir more robust

### DIFF
--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -132,8 +132,9 @@ target_include_directories(spawn PRIVATE "${PROJECT_BINARY_DIR}")
 target_include_directories(spawn PRIVATE "${PROJECT_BINARY_DIR}/modelica")
 
 target_link_libraries(spawn
-	libspawn
+  libspawn
   energypluslib
+  spawn_utils
   CONAN_PKG::CLI11
   CONAN_PKG::nlohmann_json
 )

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -13,13 +13,8 @@
 #include <stdlib.h>
 #include "../util/fmi_paths.hpp"
 #include "../util/filesystem.hpp"
+#include "../util/paths.hpp"
 
-#if defined _WIN32
-#include <windows.h>
-#else
-#include <stdio.h>
-#include <dlfcn.h>
-#endif
 
 #if defined ENABLE_MODELICA_COMPILER
 #include "compilerchain.hpp"
@@ -27,47 +22,36 @@
 
 using json = nlohmann::json;
 
-fs::path exedir() {
-  #if _WIN32
-    TCHAR szPath[MAX_PATH];
-    GetModuleFileName(nullptr, szPath, MAX_PATH);
-    return fs::path(szPath).parent_path();
-  #else
-    Dl_info info;
-    dladdr("main", &info);
-    return fs::path(info.dli_fname).parent_path();
-  #endif
-}
 
 bool isInstalled() {
-  return exedir().stem() == "bin";
+  return spawn::exedir().stem() == "bin";
 }
 
 fs::path iddInstallPath() {
   constexpr auto & iddfilename = "Energy+.idd";
   // Configuration in install tree
-  auto iddInputPath = exedir() / "../etc" / iddfilename;
+  auto iddInputPath = spawn::exedir() / "../etc" / iddfilename;
 
   // Configuration in a developer tree
   if (! fs::exists(iddInputPath)) {
-    iddInputPath = exedir() / iddfilename;
+    iddInputPath = spawn::exedir() / iddfilename;
   }
 
   return iddInputPath;
 }
 
 fs::path epfmiInstallPath() {
-  const auto candidate = exedir() / ("../lib/" + spawn::epfmi_filename());
+  const auto candidate = spawn::exedir() / ("../lib/" + spawn::epfmi_filename());
   if (fs::exists(candidate)) {
     return candidate;
   } else {
-    return exedir() / spawn::epfmi_filename();
+    return spawn::exedir() / spawn::epfmi_filename();
   }
 }
 
 fs::path jmodelicaHome() {
   if (isInstalled()) {
-    return exedir() / "../JModelica/";
+    return spawn::exedir() / "../JModelica/";
   } else {
     fs::path binary_dir(spawn::BINARY_DIR);
     return binary_dir / "JModelica/";
@@ -76,7 +60,7 @@ fs::path jmodelicaHome() {
 
 fs::path mblPath() {
   if (isInstalled()) {
-    return exedir() / "../modelica-buildings/Buildings/";
+    return spawn::exedir() / "../modelica-buildings/Buildings/";
   } else {
     fs::path source_dir(spawn::SOURCE_DIR);
     return source_dir / "submodules/modelica-buildings/Buildings/";

--- a/lib/spawn.cpp
+++ b/lib/spawn.cpp
@@ -3,6 +3,8 @@
 #include "idf_to_json.hpp"
 #include "idfprep.hpp"
 #include "input/input.hpp"
+#include "../util/paths.hpp"
+
 #include "../submodules/EnergyPlus/src/EnergyPlus/api/EnergyPlusPgm.hh"
 #include "../submodules/EnergyPlus/src/EnergyPlus/api/runtime.h"
 #include "../submodules/EnergyPlus/src/EnergyPlus/api/func.h"
@@ -21,13 +23,6 @@
 #include "../submodules/EnergyPlus/src/EnergyPlus/OutputProcessor.hh"
 #include "../submodules/EnergyPlus/src/EnergyPlus/Psychrometrics.hh"
 #include "../submodules/EnergyPlus/src/EnergyPlus/ZoneTempPredictorCorrector.hh"
-
-#if defined _WIN32
-#include <windows.h>
-#else
-#include <stdio.h>
-#include <dlfcn.h>
-#endif
 
 namespace spawn {
 
@@ -589,18 +584,6 @@ void Spawn::emptyLogMessageQueue() {
 
 EnergyPlusState Spawn::simState() {
   return reinterpret_cast<EnergyPlusState>(&sim_state);
-}
-
-fs::path exedir() {
-  #if _WIN32
-    TCHAR szPath[MAX_PATH];
-    GetModuleFileName(nullptr, szPath, MAX_PATH);
-    return fs::path(szPath).parent_path();
-  #else
-    Dl_info info;
-    dladdr("main", &info);
-    return fs::path(info.dli_fname).parent_path();
-  #endif
 }
 
 fs::path iddpath() {

--- a/lib/spawn.hpp
+++ b/lib/spawn.hpp
@@ -182,7 +182,6 @@ private:
   std::map<std::tuple<std::string, std::string, std::string>, int> actuator_handle_cache;
 };
 
-fs::path exedir();
 fs::path iddpath();
 
 } // namespace spawn

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(tests
   test_temp_directory.cpp
   test_unzip_file.cpp
   test_fmi.cpp
+  test_utils.cpp
 )
 
 add_dependencies(tests example_fmu_lib)

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -1,0 +1,82 @@
+#include "../util/paths.hpp"
+#include "paths.hpp"
+#include <catch2/catch.hpp>
+#include <iostream>
+#include <fmt/format.h>
+
+TEST_CASE("Test exe")
+{
+  const auto exe = spawn::exe();
+
+  CHECK(fs::is_regular_file(exe));
+  CHECK(!fs::is_symlink(exe));
+  CHECK(exe.is_absolute());
+
+  std::cout << spawn::exe() << '\n';
+}
+
+TEST_CASE("Test exe with different working directory")
+{
+  const auto old_working_dir = fs::current_path();
+  fs::current_path("/");
+
+  CHECK(old_working_dir != fs::current_path());
+
+  const auto exe = spawn::exe();
+
+  CHECK(fs::is_regular_file(exe));
+  CHECK(!fs::is_symlink(exe));
+  CHECK(exe.is_absolute());
+
+  std::cout << spawn::exe() << '\n';
+}
+
+
+TEST_CASE("Test exedir")
+{
+  const auto exedir = spawn::exedir();
+
+  CHECK(fs::is_directory(exedir));
+  CHECK(!fs::is_symlink(exedir));
+  CHECK(exedir.is_absolute());
+
+  std::cout << spawn::exedir() << '\n';
+}
+
+TEST_CASE("Test exedir with different working directory")
+{
+  const auto old_working_dir = fs::current_path();
+  fs::current_path(fs::temp_directory_path());
+
+  CHECK(old_working_dir != fs::current_path());
+
+  const auto exedir = spawn::exedir();
+
+  CHECK(fs::is_directory(exedir));
+  CHECK(!fs::is_symlink(exedir));
+  CHECK(exedir.is_absolute());
+
+  std::cout << spawn::exedir() << '\n';
+}
+
+TEST_CASE("Test calling exedir on self with bad exe name")
+{
+  const auto exe_name = spawn::exe().filename();
+  fs::current_path(spawn::exedir());
+  const auto results = system(fmt::format(R"(./{}asdf "Test blerb")", exe_name.native()).c_str());
+  CHECK(results != 0);
+}
+
+
+TEST_CASE("Test calling exedir on relative path for myself")
+{
+  const auto exe_name = spawn::exe().filename();
+  fs::current_path(spawn::exedir());
+  const auto results = system(fmt::format(R"(./{} "Test exedir")", exe_name.native()).c_str());
+  CHECK(results == 0);
+
+  const auto results2 = system(fmt::format(R"(./{} "Test exedir with different working directory")", exe_name.native()).c_str());
+  CHECK(results2 == 0);
+}
+
+

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -15,6 +15,8 @@ add_library(spawn_utils
         dynamiclibrary.hpp
         dynamiclibrary_windows.hpp
         dynamiclibrary_posix.hpp
+        paths.hpp
+        paths.cpp
 )
 
 target_link_libraries(spawn_utils PUBLIC energyplusapi PRIVATE CONAN_PKG::libzip)

--- a/util/filesystem.hpp
+++ b/util/filesystem.hpp
@@ -1,15 +1,18 @@
 #ifndef spawn_util_filesystem_hh_INCLUDED
 #define spawn_util_filesystem_hh_INCLUDED
 
-#if HAVE_FILESYSTEM_H 
-  #include <filesystem>
-  namespace fs = std::filesystem;
+#if HAVE_FILESYSTEM_H
+#include <filesystem>
+namespace fs = std::filesystem;
 #elif HAVE_EXP_FILESYSTEM_H
-  #include <experimental/filesystem>
-  namespace fs = std::experimental::filesystem;
-  namespace std { namespace experimental { namespace filesystem {
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+namespace std {
+namespace experimental {
+  namespace filesystem {
     // https://stackoverflow.com/questions/63899489/c-experimental-filesystem-has-no-relative-function
-    inline path relative(path p, path base) {
+    inline path relative(path p, path base)
+    {
       // 1. convert p and base to absolute paths
       p = fs::absolute(p);
       base = fs::absolute(base);
@@ -18,25 +21,28 @@
       auto mismatched = std::mismatch(p.begin(), p.end(), base.begin(), base.end());
 
       // 3. if no mismatch return "."
-      if (mismatched.first == p.end() && mismatched.second == base.end())
-        return ".";
-      
+      if (mismatched.first == p.end() && mismatched.second == base.end()) return ".";
+
       auto it_p = mismatched.first;
       auto it_base = mismatched.second;
-      
+
       path ret;
-      
+
       // 4. iterate abase to the shared root and append "../"
-      for (; it_base != base.end(); ++it_base)  ret /= ".."; 
-      
+      for (; it_base != base.end(); ++it_base)
+        ret /= "..";
+
       // 5. iterate from the shared root to the p and append its parts
-      for (; it_p != p.end(); ++it_p) ret /= *it_p; 
-      
+      for (; it_p != p.end(); ++it_p)
+        ret /= *it_p;
+
       return ret;
     }
-  }}}
+  } // namespace filesystem
+} // namespace experimental
+} // namespace std
 #else
-  #error "no filesystem support"
+#error "no filesystem support"
 #endif
 
 #endif // spawn_util_filesystem_hh_INCLUDED

--- a/util/paths.cpp
+++ b/util/paths.cpp
@@ -1,0 +1,56 @@
+#include "paths.hpp"
+#include <iostream>
+
+#if __has_include(<unistd.h>)
+#include <unistd.h>
+#include <dlfcn.h>
+#endif
+
+#if __has_include(<windows.h>)
+#include <windows.h>
+#endif
+
+
+#if __has_include(<linux/limits.h>)
+#include <linux/limits.h>
+#endif
+
+#if __has_include(<limits.h>)
+#include <limits.h>
+#endif
+
+
+namespace spawn {
+  fs::path exe() {
+  auto get_path = [](){
+    #if _WIN32
+      TCHAR szPath[MAX_PATH];
+      GetModuleFileName(nullptr, szPath, MAX_PATH);
+      return fs::path(szPath);
+    #else
+      // if /proc/self/exe exists, this should be our best option
+      char buf[PATH_MAX + 1];
+      if (const auto result = readlink("/proc/self/exe", buf, sizeof(buf) - 1); result != -1) {
+        return fs::path(std::begin(buf), std::next(buf, result));
+      }
+
+      // otherwise we'll dlopen ourselves and see where "main" exists
+      Dl_info info;
+      dladdr("main", &info);
+      return fs::path(info.dli_fname);
+    #endif
+  };
+
+  // canonical also makes the path absolute
+  static const auto path = fs::canonical(get_path());
+  return path;
+  }
+  
+fs::path exedir() {
+  static const auto path = exe().parent_path();
+  return path;
+}
+}
+
+
+

--- a/util/paths.hpp
+++ b/util/paths.hpp
@@ -1,0 +1,17 @@
+#ifndef spawn_util_paths_hh_INCLUDED
+#define spawn_util_paths_hh_INCLUDED
+
+#include "filesystem.hpp"
+
+namespace spawn {
+  // todo Move idd paths, etc into here
+  fs::path exe();
+  fs::path exedir();
+  
+}
+
+
+
+#endif
+
+


### PR DESCRIPTION
Closes #5 

 * Use the Linux proc filesystem to determine where an executable actually resides
 * Remove duplicate exedir() function, and put them in a shared location

Todo: fix iddDir() and friends to also not have duplicates, but the behavior looks slightly different, so I didn't want to break untested code.

Tests call the test executable from a new relative path to make sure the correct value is returned, which is not a relative path.