### PR TITLE
Fix embedding of files with ()

### DIFF
--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -156,15 +156,15 @@ if(ENABLE_MODELICA_COMPILER)
   list(APPEND embedded_files ${makefile})
   list(APPEND embedded_paths ${embedded_makefile})
 
-  #file(GLOB_RECURSE msl_files FOLLOW_SYMLINKS
-  #  "${jmodelica_path}/ThirdParty/MSL/**"
-  #)
+  file(GLOB_RECURSE msl_files FOLLOW_SYMLINKS
+    "${jmodelica_path}/ThirdParty/MSL/**"
+  )
   #
-  #foreach(filepath ${msl_files})
-  #  file(RELATIVE_PATH embedded_path "${jmodelica_path}/../" ${filepath})
-  #  list(APPEND embedded_files ${filepath})
-  #  list(APPEND embedded_paths ${embedded_path})
-  #endforeach()
+  foreach(filepath ${msl_files})
+    file(RELATIVE_PATH embedded_path "${jmodelica_path}/../" ${filepath})
+    list(APPEND embedded_files ${filepath})
+   list(APPEND embedded_paths ${embedded_path})
+  endforeach()
 
   # don't embed MBL for now
   #set(mbl_path "${CMAKE_BINARY_DIR}/modelica-buildings")

--- a/embedded/EmbedFiles.cmake
+++ b/embedded/EmbedFiles.cmake
@@ -49,11 +49,12 @@ function(embed_files FILES EMBEDDED_LOCATIONS CXX_OUTPUT_FILES)
     add_custom_command(OUTPUT ${EMBED_SOURCE_FILE}
       COMMAND ${CMAKE_COMMAND} -E make_directory ${EMBED_SOURCE_PATH}
       COMMAND CreateEmbeddedSource
-        ${FILE}
-        ${EMBED_SOURCE_FILE}
+        "${FILE}"
+        "${EMBED_SOURCE_FILE}"
         ${i}
-        ${EMBEDDED_LOCATION}
+        "${EMBEDDED_LOCATION}"
         DEPENDS ${FILE}
+        VERBATIM
     )
 
     set(EMBEDDED_FILE_INCLUDES "${EMBEDDED_FILE_INCLUDES}#include <${EMBED_SOURCE_FILE_REL_PATH}>\n")


### PR DESCRIPTION
Addresses #33

The main fix is the VERBATIM, but also enabled embedding of msl files for testing.

Note that this was branched from jmodelica, since it seemed to be the main workable branch right now.